### PR TITLE
Fix/inertia link reflect metadata typing

### DIFF
--- a/resources/angular/src/app/inertia/inertia-link.directive.ts
+++ b/resources/angular/src/app/inertia/inertia-link.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, Input } from '@angular/core';
+import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { router } from "@inertiajs/core";
 
 @Directive({
@@ -8,7 +8,29 @@ export class InertiaLinkDirective {
 
   @Input('inertiaLink') href = '';
 
-  @HostListener('click') onClick() {
-    router.get(this.href);
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  @HostListener('click', ['$event'])
+  onClick(event: MouseEvent) {
+    // Only handle primary (usually left) button
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Respect modifier keys so users can open in new tab/window
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    // If no explicit href input, try to read from host element (e.g. <a href="...">)
+    const href = this.href || (this.el.nativeElement.getAttribute && this.el.nativeElement.getAttribute('href')) || '';
+
+    if (!href) {
+      return;
+    }
+
+    // Prevent native navigation and use Inertia router
+    event.preventDefault();
+    router.get(href);
   }
 }


### PR DESCRIPTION
This pull request improves the `InertiaLinkDirective` in the Angular app by making click handling more robust and user-friendly. The main changes ensure that navigation respects typical browser behaviors (like modifier keys and mouse buttons), and that the directive can fall back to the element's native `href` attribute if no explicit input is provided.

Enhanced click handling and navigation logic:

* The click event handler now checks for non-primary mouse buttons and modifier keys (Ctrl, Shift, Alt, Meta), allowing users to open links in new tabs or windows as expected.
* If the `inertiaLink` input is not provided, the directive will use the host element's `href` attribute for navigation, improving flexibility and compatibility with standard anchor tags.
* The native navigation is prevented and replaced with Inertia's router navigation only when appropriate, ensuring smoother SPA transitions.

Dependency injection and imports:

* The directive now injects `ElementRef` to access the host element directly, and updates its import statements accordingly.