### PR TITLE
Fix: Respect link modifiers, ensure reflect-metadata is loaded, and type INERTIA_PAGES as array

### DIFF
--- a/resources/angular/src/app/inertia/entities.ts
+++ b/resources/angular/src/app/inertia/entities.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, Type } from '@angular/core';
 
-export const INERTIA_PAGES = new InjectionToken<InertiaPage>('INERTIA_PAGES');
+export const INERTIA_PAGES = new InjectionToken<InertiaPage[]>('INERTIA_PAGES');
 
 export enum InertiaMetadata {
   component = 'inertia:component'

--- a/resources/angular/src/app/inertia/inertia-link.directive.ts
+++ b/resources/angular/src/app/inertia/inertia-link.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, Input } from '@angular/core';
+import { Directive, HostListener, Input, ElementRef } from '@angular/core';
 import { router } from "@inertiajs/core";
 
 @Directive({
@@ -8,7 +8,29 @@ export class InertiaLinkDirective {
 
   @Input('inertiaLink') href = '';
 
-  @HostListener('click') onClick() {
-    router.get(this.href);
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  @HostListener('click', ['$event'])
+  onClick(event: MouseEvent) {
+    // Only handle primary (usually left) button
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Respect modifier keys so users can open in new tab/window
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    // If no explicit href input, try to read from host element (e.g. <a href="...">)
+    const href = this.href || (this.el.nativeElement.getAttribute && this.el.nativeElement.getAttribute('href')) || '';
+
+    if (!href) {
+      return;
+    }
+
+    // Prevent native navigation and use Inertia router
+    event.preventDefault();
+    router.get(href);
   }
 }

--- a/resources/angular/src/main.ts
+++ b/resources/angular/src/main.ts
@@ -1,3 +1,6 @@
+// Ensure reflect-metadata is loaded before decorators are evaluated.
+import 'reflect-metadata';
+
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';


### PR DESCRIPTION
This pull request introduces improvements to the Angular Inertia integration, focusing on enhancing the `InertiaLinkDirective` for better usability and standards compliance, and making minor adjustments to dependency injection and application bootstrapping.

**Enhancements to Inertia Link Handling:**

* Improved the `InertiaLinkDirective` to handle click events more robustly:
  - Now only triggers navigation for primary (left) mouse button clicks.
  - Respects modifier keys (Ctrl, Shift, Alt, Meta) to allow users to open links in new tabs or windows.
  - Falls back to the host element's `href` attribute if the directive input is not provided.
  - Prevents native navigation and uses the Inertia router for SPA navigation.

* Added `ElementRef` injection to `InertiaLinkDirective` to support reading attributes from the host element.

**Dependency Injection Update:**

* Changed the `INERTIA_PAGES` injection token to provide an array of `InertiaPage` instead of a single page, improving scalability for multi-page setups.

**Application Bootstrapping:**

* Ensured that `reflect-metadata` is loaded before Angular decorators are evaluated, which is required for proper decorator behavior.